### PR TITLE
Add HL7→FHIR mapping logic

### DIFF
--- a/scripts/map_adt_a03.py
+++ b/scripts/map_adt_a03.py
@@ -16,10 +16,52 @@ PID|1||12345^^^MR||Doe^John||19800101|M
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:
-    """Stub converter. Extend this for full mapping."""
-    bundle = Bundle.construct()
+    """Convert HL7 ADT_A03 message to a FHIR Bundle with MessageHeader and Patient resources."""
+    msg = parser.parse_message(hl7_str)
+    msh = msg.MSH
+    pid = msg.PID
+
+    bundle = Bundle.model_construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "ADT_A03"}]}
+    bundle.entry = []
+
+    from fhir.resources.bundle import BundleEntry
+    from fhir.resources.messageheader import MessageHeader
+    from fhir.resources.coding import Coding
+    from fhir.resources.patient import Patient
+    from fhir.resources.humanname import HumanName
+    import datetime
+
+    mh = MessageHeader.model_construct()
+    mh.eventCoding = Coding.model_construct()
+    mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
+    mh.eventCoding.code = msh.MSH_9.value
+    mh.id = "message-header"
+    mh.source = {"name": msh.MSH_3.value}
+    mh.destination = [{"name": msh.MSH_5.value}]
+    ts = msh.MSH_7.value
+    dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
+    mh.timestamp = dt.isoformat()
+
+    mh_entry = BundleEntry.model_construct()
+    mh_entry.fullUrl = "urn:uuid:message-header"
+    mh_entry.resource = mh
+    bundle.entry.append(mh_entry)
+
+    pat = Patient.model_construct()
+    pat.id = pid.PID_3.value.split("^")[0]
+    parts = pid.PID_5.value.split("^")
+    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    bd = pid.PID_7.value
+    pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
+    pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
+
+    pat_entry = BundleEntry.model_construct()
+    pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
+    pat_entry.resource = pat
+    bundle.entry.append(pat_entry)
+
     return bundle
 
 

--- a/scripts/map_dft_p03.py
+++ b/scripts/map_dft_p03.py
@@ -16,10 +16,52 @@ PID|1||12345^^^MR||Doe^John||19800101|M
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:
-    """Stub converter. Extend this for full mapping."""
-    bundle = Bundle.construct()
+    """Convert HL7 DFT_P03 message to a FHIR Bundle with MessageHeader and Patient resources."""
+    msg = parser.parse_message(hl7_str)
+    msh = msg.MSH
+    pid = msg.PID
+
+    bundle = Bundle.model_construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "DFT_P03"}]}
+    bundle.entry = []
+
+    from fhir.resources.bundle import BundleEntry
+    from fhir.resources.messageheader import MessageHeader
+    from fhir.resources.coding import Coding
+    from fhir.resources.patient import Patient
+    from fhir.resources.humanname import HumanName
+    import datetime
+
+    mh = MessageHeader.model_construct()
+    mh.eventCoding = Coding.model_construct()
+    mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
+    mh.eventCoding.code = msh.MSH_9.value
+    mh.id = "message-header"
+    mh.source = {"name": msh.MSH_3.value}
+    mh.destination = [{"name": msh.MSH_5.value}]
+    ts = msh.MSH_7.value
+    dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
+    mh.timestamp = dt.isoformat()
+
+    mh_entry = BundleEntry.model_construct()
+    mh_entry.fullUrl = "urn:uuid:message-header"
+    mh_entry.resource = mh
+    bundle.entry.append(mh_entry)
+
+    pat = Patient.model_construct()
+    pat.id = pid.PID_3.value.split("^")[0]
+    parts = pid.PID_5.value.split("^")
+    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    bd = pid.PID_7.value
+    pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
+    pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
+
+    pat_entry = BundleEntry.model_construct()
+    pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
+    pat_entry.resource = pat
+    bundle.entry.append(pat_entry)
+
     return bundle
 
 

--- a/scripts/map_mdm_t02.py
+++ b/scripts/map_mdm_t02.py
@@ -16,10 +16,52 @@ PID|1||12345^^^MR||Doe^John||19800101|M
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:
-    """Stub converter. Extend this for full mapping."""
-    bundle = Bundle.construct()
+    """Convert HL7 MDM_T02 message to a FHIR Bundle with MessageHeader and Patient resources."""
+    msg = parser.parse_message(hl7_str)
+    msh = msg.MSH
+    pid = msg.PID
+
+    bundle = Bundle.model_construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "MDM_T02"}]}
+    bundle.entry = []
+
+    from fhir.resources.bundle import BundleEntry
+    from fhir.resources.messageheader import MessageHeader
+    from fhir.resources.coding import Coding
+    from fhir.resources.patient import Patient
+    from fhir.resources.humanname import HumanName
+    import datetime
+
+    mh = MessageHeader.model_construct()
+    mh.eventCoding = Coding.model_construct()
+    mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
+    mh.eventCoding.code = msh.MSH_9.value
+    mh.id = "message-header"
+    mh.source = {"name": msh.MSH_3.value}
+    mh.destination = [{"name": msh.MSH_5.value}]
+    ts = msh.MSH_7.value
+    dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
+    mh.timestamp = dt.isoformat()
+
+    mh_entry = BundleEntry.model_construct()
+    mh_entry.fullUrl = "urn:uuid:message-header"
+    mh_entry.resource = mh
+    bundle.entry.append(mh_entry)
+
+    pat = Patient.model_construct()
+    pat.id = pid.PID_3.value.split("^")[0]
+    parts = pid.PID_5.value.split("^")
+    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    bd = pid.PID_7.value
+    pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
+    pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
+
+    pat_entry = BundleEntry.model_construct()
+    pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
+    pat_entry.resource = pat
+    bundle.entry.append(pat_entry)
+
     return bundle
 
 

--- a/scripts/map_orm_o01.py
+++ b/scripts/map_orm_o01.py
@@ -16,10 +16,52 @@ PID|1||12345^^^MR||Doe^John||19800101|M
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:
-    """Stub converter. Extend this for full mapping."""
-    bundle = Bundle.construct()
+    """Convert HL7 ORM_O01 message to a FHIR Bundle with MessageHeader and Patient resources."""
+    msg = parser.parse_message(hl7_str)
+    msh = msg.MSH
+    pid = msg.PID
+
+    bundle = Bundle.model_construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "ORM_O01"}]}
+    bundle.entry = []
+
+    from fhir.resources.bundle import BundleEntry
+    from fhir.resources.messageheader import MessageHeader
+    from fhir.resources.coding import Coding
+    from fhir.resources.patient import Patient
+    from fhir.resources.humanname import HumanName
+    import datetime
+
+    mh = MessageHeader.model_construct()
+    mh.eventCoding = Coding.model_construct()
+    mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
+    mh.eventCoding.code = msh.MSH_9.value
+    mh.id = "message-header"
+    mh.source = {"name": msh.MSH_3.value}
+    mh.destination = [{"name": msh.MSH_5.value}]
+    ts = msh.MSH_7.value
+    dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
+    mh.timestamp = dt.isoformat()
+
+    mh_entry = BundleEntry.model_construct()
+    mh_entry.fullUrl = "urn:uuid:message-header"
+    mh_entry.resource = mh
+    bundle.entry.append(mh_entry)
+
+    pat = Patient.model_construct()
+    pat.id = pid.PID_3.value.split("^")[0]
+    parts = pid.PID_5.value.split("^")
+    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    bd = pid.PID_7.value
+    pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
+    pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
+
+    pat_entry = BundleEntry.model_construct()
+    pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
+    pat_entry.resource = pat
+    bundle.entry.append(pat_entry)
+
     return bundle
 
 

--- a/scripts/map_oru_r01.py
+++ b/scripts/map_oru_r01.py
@@ -16,10 +16,52 @@ PID|1||12345^^^MR||Doe^John||19800101|M
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:
-    """Stub converter. Extend this for full mapping."""
-    bundle = Bundle.construct()
+    """Convert HL7 ORU_R01 message to a FHIR Bundle with MessageHeader and Patient resources."""
+    msg = parser.parse_message(hl7_str)
+    msh = msg.MSH
+    pid = msg.PID
+
+    bundle = Bundle.model_construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "ORU_R01"}]}
+    bundle.entry = []
+
+    from fhir.resources.bundle import BundleEntry
+    from fhir.resources.messageheader import MessageHeader
+    from fhir.resources.coding import Coding
+    from fhir.resources.patient import Patient
+    from fhir.resources.humanname import HumanName
+    import datetime
+
+    mh = MessageHeader.model_construct()
+    mh.eventCoding = Coding.model_construct()
+    mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
+    mh.eventCoding.code = msh.MSH_9.value
+    mh.id = "message-header"
+    mh.source = {"name": msh.MSH_3.value}
+    mh.destination = [{"name": msh.MSH_5.value}]
+    ts = msh.MSH_7.value
+    dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
+    mh.timestamp = dt.isoformat()
+
+    mh_entry = BundleEntry.model_construct()
+    mh_entry.fullUrl = "urn:uuid:message-header"
+    mh_entry.resource = mh
+    bundle.entry.append(mh_entry)
+
+    pat = Patient.model_construct()
+    pat.id = pid.PID_3.value.split("^")[0]
+    parts = pid.PID_5.value.split("^")
+    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    bd = pid.PID_7.value
+    pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
+    pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
+
+    pat_entry = BundleEntry.model_construct()
+    pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
+    pat_entry.resource = pat
+    bundle.entry.append(pat_entry)
+
     return bundle
 
 

--- a/scripts/map_qry_a19.py
+++ b/scripts/map_qry_a19.py
@@ -16,10 +16,52 @@ PID|1||12345^^^MR||Doe^John||19800101|M
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:
-    """Stub converter. Extend this for full mapping."""
-    bundle = Bundle.construct()
+    """Convert HL7 QRY_A19 message to a FHIR Bundle with MessageHeader and Patient resources."""
+    msg = parser.parse_message(hl7_str)
+    msh = msg.MSH
+    pid = msg.PID
+
+    bundle = Bundle.model_construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "QRY_A19"}]}
+    bundle.entry = []
+
+    from fhir.resources.bundle import BundleEntry
+    from fhir.resources.messageheader import MessageHeader
+    from fhir.resources.coding import Coding
+    from fhir.resources.patient import Patient
+    from fhir.resources.humanname import HumanName
+    import datetime
+
+    mh = MessageHeader.model_construct()
+    mh.eventCoding = Coding.model_construct()
+    mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
+    mh.eventCoding.code = msh.MSH_9.value
+    mh.id = "message-header"
+    mh.source = {"name": msh.MSH_3.value}
+    mh.destination = [{"name": msh.MSH_5.value}]
+    ts = msh.MSH_7.value
+    dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
+    mh.timestamp = dt.isoformat()
+
+    mh_entry = BundleEntry.model_construct()
+    mh_entry.fullUrl = "urn:uuid:message-header"
+    mh_entry.resource = mh
+    bundle.entry.append(mh_entry)
+
+    pat = Patient.model_construct()
+    pat.id = pid.PID_3.value.split("^")[0]
+    parts = pid.PID_5.value.split("^")
+    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    bd = pid.PID_7.value
+    pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
+    pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
+
+    pat_entry = BundleEntry.model_construct()
+    pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
+    pat_entry.resource = pat
+    bundle.entry.append(pat_entry)
+
     return bundle
 
 

--- a/scripts/map_rde_o11.py
+++ b/scripts/map_rde_o11.py
@@ -16,10 +16,52 @@ PID|1||12345^^^MR||Doe^John||19800101|M
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:
-    """Stub converter. Extend this for full mapping."""
-    bundle = Bundle.construct()
+    """Convert HL7 RDE_O11 message to a FHIR Bundle with MessageHeader and Patient resources."""
+    msg = parser.parse_message(hl7_str)
+    msh = msg.MSH
+    pid = msg.PID
+
+    bundle = Bundle.model_construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "RDE_O11"}]}
+    bundle.entry = []
+
+    from fhir.resources.bundle import BundleEntry
+    from fhir.resources.messageheader import MessageHeader
+    from fhir.resources.coding import Coding
+    from fhir.resources.patient import Patient
+    from fhir.resources.humanname import HumanName
+    import datetime
+
+    mh = MessageHeader.model_construct()
+    mh.eventCoding = Coding.model_construct()
+    mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
+    mh.eventCoding.code = msh.MSH_9.value
+    mh.id = "message-header"
+    mh.source = {"name": msh.MSH_3.value}
+    mh.destination = [{"name": msh.MSH_5.value}]
+    ts = msh.MSH_7.value
+    dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
+    mh.timestamp = dt.isoformat()
+
+    mh_entry = BundleEntry.model_construct()
+    mh_entry.fullUrl = "urn:uuid:message-header"
+    mh_entry.resource = mh
+    bundle.entry.append(mh_entry)
+
+    pat = Patient.model_construct()
+    pat.id = pid.PID_3.value.split("^")[0]
+    parts = pid.PID_5.value.split("^")
+    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    bd = pid.PID_7.value
+    pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
+    pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
+
+    pat_entry = BundleEntry.model_construct()
+    pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
+    pat_entry.resource = pat
+    bundle.entry.append(pat_entry)
+
     return bundle
 
 

--- a/scripts/map_siu_s12.py
+++ b/scripts/map_siu_s12.py
@@ -16,10 +16,52 @@ PID|1||12345^^^MR||Doe^John||19800101|M
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:
-    """Stub converter. Extend this for full mapping."""
-    bundle = Bundle.construct()
+    """Convert HL7 SIU_S12 message to a FHIR Bundle with MessageHeader and Patient resources."""
+    msg = parser.parse_message(hl7_str)
+    msh = msg.MSH
+    pid = msg.PID
+
+    bundle = Bundle.model_construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "SIU_S12"}]}
+    bundle.entry = []
+
+    from fhir.resources.bundle import BundleEntry
+    from fhir.resources.messageheader import MessageHeader
+    from fhir.resources.coding import Coding
+    from fhir.resources.patient import Patient
+    from fhir.resources.humanname import HumanName
+    import datetime
+
+    mh = MessageHeader.model_construct()
+    mh.eventCoding = Coding.model_construct()
+    mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
+    mh.eventCoding.code = msh.MSH_9.value
+    mh.id = "message-header"
+    mh.source = {"name": msh.MSH_3.value}
+    mh.destination = [{"name": msh.MSH_5.value}]
+    ts = msh.MSH_7.value
+    dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
+    mh.timestamp = dt.isoformat()
+
+    mh_entry = BundleEntry.model_construct()
+    mh_entry.fullUrl = "urn:uuid:message-header"
+    mh_entry.resource = mh
+    bundle.entry.append(mh_entry)
+
+    pat = Patient.model_construct()
+    pat.id = pid.PID_3.value.split("^")[0]
+    parts = pid.PID_5.value.split("^")
+    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    bd = pid.PID_7.value
+    pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
+    pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
+
+    pat_entry = BundleEntry.model_construct()
+    pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
+    pat_entry.resource = pat
+    bundle.entry.append(pat_entry)
+
     return bundle
 
 


### PR DESCRIPTION
## Summary
- map MSH/PID segments for ACK, ADT_A03, DFT_P03, MDM_T02, ORM_O01, ORU_R01, QRY_A19, RDE_O11 and SIU_S12 scripts
- create MessageHeader and Patient resources for each stub HL7 message

## Testing
- `pip install -r requirements.txt` *(fails: Could not find hl7apy==1.3.5)*
- `pytest -q` *(fails: command not found)*