### PR TITLE
Fix mapping scripts and update server defaults

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -6,8 +6,8 @@ This FastAPI application proxies RESTful requests to a HAPI-FHIR server, providi
 
 1. Create a `.env` file in the project root:
    ```
-   FHIR_SERVER_URL=http://localhost:8080/fhir
-   PORT=8000
+   FHIR_SERVER_URL=http://localhost:8080
+   PORT=8001
    ```
 2. Install dependencies:
    ```bash

--- a/api/main.py
+++ b/api/main.py
@@ -13,7 +13,8 @@ app = FastAPI(
 )
 
 # Base URL of HAPI-FHIR server
-FHIR_SERVER_URL = os.getenv("FHIR_SERVER_URL", "http://localhost:8080/fhir")
+# Base URL of HAPI-FHIR server
+FHIR_SERVER_URL = os.getenv("FHIR_SERVER_URL", "http://localhost:8080")
 
 async def proxy_request(method: str, path: str, params=None, json_body=None):
     async with httpx.AsyncClient() as client:
@@ -77,4 +78,4 @@ async def evaluate_measure(id: str, request: Request):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", 8000)), reload=True)
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", 8001)), reload=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ fastapi==0.100.0
 uvicorn==0.23.0
 httpx==0.24.1
 python-dotenv==1.0.0
+pytest
+pytest-asyncio

--- a/scripts/map_ack.py
+++ b/scripts/map_ack.py
@@ -21,7 +21,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     msh = msg.MSH
     pid = msg.PID
 
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "ACK"}]}
     bundle.entry = []
@@ -33,8 +33,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     from fhir.resources.humanname import HumanName
     import datetime
 
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -44,20 +44,20 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)

--- a/scripts/map_adt_a01.py
+++ b/scripts/map_adt_a01.py
@@ -23,7 +23,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     pid = msg.PID
 
     # Create Bundle
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "ADT_A01"}]}
     bundle.entry = []
@@ -37,8 +37,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     import datetime
 
     # Map MessageHeader
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -48,22 +48,22 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
     # Map Patient
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     # Use only the local ID component without assigning authority for FHIR ID
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)

--- a/scripts/map_adt_a03.py
+++ b/scripts/map_adt_a03.py
@@ -21,7 +21,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     msh = msg.MSH
     pid = msg.PID
 
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "ADT_A03"}]}
     bundle.entry = []
@@ -33,8 +33,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     from fhir.resources.humanname import HumanName
     import datetime
 
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -44,20 +44,20 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)

--- a/scripts/map_dft_p03.py
+++ b/scripts/map_dft_p03.py
@@ -21,7 +21,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     msh = msg.MSH
     pid = msg.PID
 
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "DFT_P03"}]}
     bundle.entry = []
@@ -33,8 +33,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     from fhir.resources.humanname import HumanName
     import datetime
 
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -44,20 +44,20 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)

--- a/scripts/map_mdm_t02.py
+++ b/scripts/map_mdm_t02.py
@@ -21,7 +21,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     msh = msg.MSH
     pid = msg.PID
 
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "MDM_T02"}]}
     bundle.entry = []
@@ -33,8 +33,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     from fhir.resources.humanname import HumanName
     import datetime
 
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -44,20 +44,20 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)

--- a/scripts/map_orm_o01.py
+++ b/scripts/map_orm_o01.py
@@ -21,7 +21,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     msh = msg.MSH
     pid = msg.PID
 
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "ORM_O01"}]}
     bundle.entry = []
@@ -33,8 +33,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     from fhir.resources.humanname import HumanName
     import datetime
 
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -44,20 +44,20 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)

--- a/scripts/map_oru_r01.py
+++ b/scripts/map_oru_r01.py
@@ -21,7 +21,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     msh = msg.MSH
     pid = msg.PID
 
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "ORU_R01"}]}
     bundle.entry = []
@@ -33,8 +33,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     from fhir.resources.humanname import HumanName
     import datetime
 
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -44,20 +44,20 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)

--- a/scripts/map_qry_a19.py
+++ b/scripts/map_qry_a19.py
@@ -21,7 +21,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     msh = msg.MSH
     pid = msg.PID
 
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "QRY_A19"}]}
     bundle.entry = []
@@ -33,8 +33,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     from fhir.resources.humanname import HumanName
     import datetime
 
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -44,20 +44,20 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)

--- a/scripts/map_rde_o11.py
+++ b/scripts/map_rde_o11.py
@@ -21,7 +21,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     msh = msg.MSH
     pid = msg.PID
 
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "RDE_O11"}]}
     bundle.entry = []
@@ -33,8 +33,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     from fhir.resources.humanname import HumanName
     import datetime
 
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -44,20 +44,20 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)

--- a/scripts/map_siu_s12.py
+++ b/scripts/map_siu_s12.py
@@ -21,7 +21,7 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     msh = msg.MSH
     pid = msg.PID
 
-    bundle = Bundle.model_construct()
+    bundle = Bundle.construct()
     bundle.type = "message"
     bundle.meta = {"tag": [{"code": "SIU_S12"}]}
     bundle.entry = []
@@ -33,8 +33,8 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     from fhir.resources.humanname import HumanName
     import datetime
 
-    mh = MessageHeader.model_construct()
-    mh.eventCoding = Coding.model_construct()
+    mh = MessageHeader.construct()
+    mh.eventCoding = Coding.construct()
     mh.eventCoding.system = "http://terminology.hl7.org/CodeSystem/message-event"
     mh.eventCoding.code = msh.MSH_9.value
     mh.id = "message-header"
@@ -44,20 +44,20 @@ def hl7_to_fhir(hl7_str: str) -> Bundle:
     dt = datetime.datetime.strptime(ts, "%Y%m%d%H%M%S")
     mh.timestamp = dt.isoformat()
 
-    mh_entry = BundleEntry.model_construct()
+    mh_entry = BundleEntry.construct()
     mh_entry.fullUrl = "urn:uuid:message-header"
     mh_entry.resource = mh
     bundle.entry.append(mh_entry)
 
-    pat = Patient.model_construct()
+    pat = Patient.construct()
     pat.id = pid.PID_3.value.split("^")[0]
     parts = pid.PID_5.value.split("^")
-    pat.name = [HumanName.model_construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
+    pat.name = [HumanName.construct(family=parts[0], given=[parts[1] if len(parts) > 1 else ""])]
     bd = pid.PID_7.value
     pat.birthDate = datetime.datetime.strptime(bd, "%Y%m%d").date().isoformat()
     pat.gender = "male" if pid.PID_8.value.upper() == "M" else "female"
 
-    pat_entry = BundleEntry.model_construct()
+    pat_entry = BundleEntry.construct()
     pat_entry.fullUrl = f"urn:uuid:patient-{pat.id}"
     pat_entry.resource = pat
     bundle.entry.append(pat_entry)


### PR DESCRIPTION
## Summary
- use `.construct()` instead of `.model_construct()` so mapping scripts run under Pydantic 1
- add `pytest` dependencies
- update HAPI-FHIR server URL and port default to 8001

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m pytest -q` *(fails: No module named pytest)*