### PR TITLE
Fix stub HL7 messages

### DIFF
--- a/scripts/map_ack.py
+++ b/scripts/map_ack.py
@@ -10,9 +10,10 @@ Dependencies:
 from hl7apy import parser
 from fhir.resources.bundle import Bundle
 
-STUB_HL7_MESSAGE = """MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||ACK|123456|P|2.5
-PID|1||12345^^^MR||Doe^John||19800101|M
-"""  # noqa: E501
+STUB_HL7_MESSAGE = (
+    "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||ACK|123456|P|2.5\\r"
+    "PID|1||12345^^^MR||Doe^John||19800101|M\\r"
+)  # noqa: E501
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:

--- a/scripts/map_adt_a03.py
+++ b/scripts/map_adt_a03.py
@@ -10,9 +10,10 @@ Dependencies:
 from hl7apy import parser
 from fhir.resources.bundle import Bundle
 
-STUB_HL7_MESSAGE = """MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||ADT|123456|P|2.5
-PID|1||12345^^^MR||Doe^John||19800101|M
-"""  # noqa: E501
+STUB_HL7_MESSAGE = (
+    "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||ADT|123456|P|2.5\\r"
+    "PID|1||12345^^^MR||Doe^John||19800101|M\\r"
+)  # noqa: E501
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:

--- a/scripts/map_dft_p03.py
+++ b/scripts/map_dft_p03.py
@@ -10,9 +10,10 @@ Dependencies:
 from hl7apy import parser
 from fhir.resources.bundle import Bundle
 
-STUB_HL7_MESSAGE = """MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||DFT|123456|P|2.5
-PID|1||12345^^^MR||Doe^John||19800101|M
-"""  # noqa: E501
+STUB_HL7_MESSAGE = (
+    "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||DFT|123456|P|2.5\\r"
+    "PID|1||12345^^^MR||Doe^John||19800101|M\\r"
+)  # noqa: E501
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:

--- a/scripts/map_mdm_t02.py
+++ b/scripts/map_mdm_t02.py
@@ -10,9 +10,10 @@ Dependencies:
 from hl7apy import parser
 from fhir.resources.bundle import Bundle
 
-STUB_HL7_MESSAGE = """MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||MDM|123456|P|2.5
-PID|1||12345^^^MR||Doe^John||19800101|M
-"""  # noqa: E501
+STUB_HL7_MESSAGE = (
+    "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||MDM|123456|P|2.5\\r"
+    "PID|1||12345^^^MR||Doe^John||19800101|M\\r"
+)  # noqa: E501
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:

--- a/scripts/map_orm_o01.py
+++ b/scripts/map_orm_o01.py
@@ -10,9 +10,10 @@ Dependencies:
 from hl7apy import parser
 from fhir.resources.bundle import Bundle
 
-STUB_HL7_MESSAGE = """MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||ORM|123456|P|2.5
-PID|1||12345^^^MR||Doe^John||19800101|M
-"""  # noqa: E501
+STUB_HL7_MESSAGE = (
+    "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||ORM|123456|P|2.5\\r"
+    "PID|1||12345^^^MR||Doe^John||19800101|M\\r"
+)  # noqa: E501
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:

--- a/scripts/map_oru_r01.py
+++ b/scripts/map_oru_r01.py
@@ -10,9 +10,10 @@ Dependencies:
 from hl7apy import parser
 from fhir.resources.bundle import Bundle
 
-STUB_HL7_MESSAGE = """MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||ORU|123456|P|2.5
-PID|1||12345^^^MR||Doe^John||19800101|M
-"""  # noqa: E501
+STUB_HL7_MESSAGE = (
+    "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||ORU|123456|P|2.5\\r"
+    "PID|1||12345^^^MR||Doe^John||19800101|M\\r"
+)  # noqa: E501
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:

--- a/scripts/map_qry_a19.py
+++ b/scripts/map_qry_a19.py
@@ -10,9 +10,10 @@ Dependencies:
 from hl7apy import parser
 from fhir.resources.bundle import Bundle
 
-STUB_HL7_MESSAGE = """MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||QRY|123456|P|2.5
-PID|1||12345^^^MR||Doe^John||19800101|M
-"""  # noqa: E501
+STUB_HL7_MESSAGE = (
+    "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||QRY|123456|P|2.5\\r"
+    "PID|1||12345^^^MR||Doe^John||19800101|M\\r"
+)  # noqa: E501
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:

--- a/scripts/map_rde_o11.py
+++ b/scripts/map_rde_o11.py
@@ -10,9 +10,10 @@ Dependencies:
 from hl7apy import parser
 from fhir.resources.bundle import Bundle
 
-STUB_HL7_MESSAGE = """MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||RDE|123456|P|2.5
-PID|1||12345^^^MR||Doe^John||19800101|M
-"""  # noqa: E501
+STUB_HL7_MESSAGE = (
+    "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||RDE|123456|P|2.5\\r"
+    "PID|1||12345^^^MR||Doe^John||19800101|M\\r"
+)  # noqa: E501
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:

--- a/scripts/map_siu_s12.py
+++ b/scripts/map_siu_s12.py
@@ -10,9 +10,10 @@ Dependencies:
 from hl7apy import parser
 from fhir.resources.bundle import Bundle
 
-STUB_HL7_MESSAGE = """MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||SIU|123456|P|2.5
-PID|1||12345^^^MR||Doe^John||19800101|M
-"""  # noqa: E501
+STUB_HL7_MESSAGE = (
+    "MSH|^~\\&|SendingApp|SendingFac|ReceivingApp|ReceivingFac|20250420130120||SIU|123456|P|2.5\\r"
+    "PID|1||12345^^^MR||Doe^John||19800101|M\\r"
+)  # noqa: E501
 
 
 def hl7_to_fhir(hl7_str: str) -> Bundle:


### PR DESCRIPTION
## Summary
- fix HL7 stub message formatting for ACK and other scripts

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*