### PR TITLE
Add pydantic pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ fastapi==0.100.0
 uvicorn==0.23.0
 httpx==0.24.1
 python-dotenv==1.0.0
+pydantic<2
 pytest
 pytest-asyncio


### PR DESCRIPTION
## Summary
- require `pydantic<2` in `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: no route to host)*
- `pytest -q` *(fails: command not found)*