### PR TITLE
Fix unused import

### DIFF
--- a/generate_scaffold.py
+++ b/generate_scaffold.py
@@ -6,7 +6,7 @@ Edit `message_types` then run:
     python generate_scaffold.py
 """
 
-import os, datetime, textwrap
+import os, datetime
 
 message_types = [
     'ADT_A01', 'ADT_A03',


### PR DESCRIPTION
## Summary
- remove unused `textwrap` import from generate_scaffold.py

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m pytest -q` *(fails: No module named pytest)*