### PR TITLE
Fix duplicate comment in main

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -13,7 +13,6 @@ app = FastAPI(
 )
 
 # Base URL of HAPI-FHIR server
-# Base URL of HAPI-FHIR server
 FHIR_SERVER_URL = os.getenv("FHIR_SERVER_URL", "http://localhost:8080")
 
 async def proxy_request(method: str, path: str, params=None, json_body=None):


### PR DESCRIPTION
## Summary
- remove repeated comment in `api/main.py`

## Testing
- `pip3 install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: command not found)*